### PR TITLE
StringConverter Overhaul

### DIFF
--- a/LethalAPI.TerminalCommands/Attributes/StringConverterAttribute.cs
+++ b/LethalAPI.TerminalCommands/Attributes/StringConverterAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace LethalAPI.TerminalCommands.Attributes
+{
+	public sealed class StringConverterAttribute : Attribute
+	{
+	}
+}

--- a/LethalAPI.TerminalCommands/Attributes/StringConverterAttribute.cs
+++ b/LethalAPI.TerminalCommands/Attributes/StringConverterAttribute.cs
@@ -2,6 +2,16 @@
 
 namespace LethalAPI.TerminalCommands.Attributes
 {
+	/// <summary>
+	/// Used to mark a method as a string converter.
+	/// </summary>
+	/// <remarks>
+	/// String converters should take only a single argument of a string, and return the type they convert strings to
+	/// <para>
+	/// String Converter methods can throw <seealso cref="ArgumentException"/> if the input string is in the incorrect format
+	/// </para>
+	/// </remarks>
+	[AttributeUsage(AttributeTargets.Method)]
 	public sealed class StringConverterAttribute : Attribute
 	{
 	}

--- a/LethalAPI.TerminalCommands/Commands/CommandInfoCommands.cs
+++ b/LethalAPI.TerminalCommands/Commands/CommandInfoCommands.cs
@@ -30,7 +30,7 @@ namespace LethalAPI.TerminalCommands.Commands
 			builder.AppendLine("To scan for the number of items left on the current planet");
 			builder.AppendLine();
 
-			foreach (var command in CommandRegistry.EnumerateCommands())
+			foreach (var command in TerminalRegistry.EnumerateCommands())
 			{
 				if (command.Description == null)
 				{
@@ -55,7 +55,7 @@ namespace LethalAPI.TerminalCommands.Commands
 		public string HelpCommand(string name)
 		{
 			var builder = new StringBuilder();
-			var commands = CommandRegistry.EnumerateCommands(name).ToArray();
+			var commands = TerminalRegistry.EnumerateCommands(name).ToArray();
 
 			if (commands.Length == 0)
 			{

--- a/LethalAPI.TerminalCommands/Models/CommandHandler.cs
+++ b/LethalAPI.TerminalCommands/Models/CommandHandler.cs
@@ -36,7 +36,7 @@ namespace LethalAPI.TerminalCommands.Models
 
 			var candidateCommands = new List<(TerminalCommand command, Func<TerminalNode> invoker)>();
 
-			var overloads = CommandRegistry.GetCommands(commandName).ToArray();
+			var overloads = TerminalRegistry.GetCommands(commandName).ToArray();
 
 			for (int i = 0; i < overloads.Length; i++)
 			{

--- a/LethalAPI.TerminalCommands/Models/DefaultStringConverters.cs
+++ b/LethalAPI.TerminalCommands/Models/DefaultStringConverters.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Linq;
+using GameNetcodeStuff;
+using LethalAPI.TerminalCommands.Attributes;
+
+namespace LethalAPI.TerminalCommands.Models
+{
+	/// <summary>
+	/// Contains the default built-in string type converters
+	/// </summary>
+	public static class DefaultStringConverters
+	{
+		[StringConverter]
+		public static string ParseString(string input)
+		{
+			return input;
+		}
+
+		[StringConverter]
+		public static sbyte ParseSByte(string input)
+		{
+			if (sbyte.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static byte ParseByte(string input)
+		{
+			if (byte.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static short ParseShort(string input)
+		{
+			if (short.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static ushort ParseUShort(string input)
+		{
+			if (ushort.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static int ParseInt(string input)
+		{
+			if (int.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static uint ParseUInt(string input)
+		{
+			if (uint.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static long ParseLong(string input)
+		{
+			if (long.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static ulong ParseULong(string input)
+		{
+			if (ulong.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static float ParseFloat(string input)
+		{
+			if (float.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static double ParseDouble(string input)
+		{
+			if (double.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		[StringConverter]
+		public static decimal ParseDecimal(string input)
+		{
+			if (decimal.TryParse(input, out var value))
+			{
+				return value;
+			}
+			throw new ArgumentException();
+		}
+
+		public static PlayerControllerB ParsePlayerControllerB(string value)
+		{
+			if (StartOfRound.Instance == null) // Game not started
+			{
+				throw new ArgumentException("Game has not started");
+			}
+
+			PlayerControllerB player = null;
+			if (ulong.TryParse(value, out var steamID))
+			{
+				player = StartOfRound.Instance.allPlayerScripts
+										.FirstOrDefault(x => x.playerSteamId == steamID);
+			}
+
+			if (player == null)
+			{
+				player = StartOfRound.Instance.allPlayerScripts
+										.FirstOrDefault(x => x.playerUsername.IndexOf(value, StringComparison.InvariantCultureIgnoreCase) != -1);
+			}
+
+			if (player == null)
+			{
+				throw new ArgumentException("Failed to find player");
+			}
+
+			return player;
+		}
+	}
+}

--- a/LethalAPI.TerminalCommands/Models/TerminalModRegistry.cs
+++ b/LethalAPI.TerminalCommands/Models/TerminalModRegistry.cs
@@ -5,15 +5,12 @@ namespace LethalAPI.TerminalCommands.Models
 	/// <summary>
 	/// A local terminal command registry for a mod. Allows all commands registered to an instance to be deregistered
 	/// </summary>
-	public class ModCommands
+	public class TerminalModRegistry
 	{
 		/// <summary>
 		/// Command instances registered to this instance
 		/// </summary>
 		public List<TerminalCommand> Commands { get; } = new List<TerminalCommand>();
-
-
-
 
 		/// <summary>
 		/// Creates a new instance of the specified type, and registers all commands from it
@@ -31,17 +28,20 @@ namespace LethalAPI.TerminalCommands.Models
 		/// <param name="instance">Instance to execute commands in</param>
 		public T RegisterFrom<T>(T instance) where T : class
 		{
-			foreach (var method in CommandRegistry.GetCommandMethods<T>())
+			foreach (var method in TerminalRegistry.GetCommandMethods<T>())
 			{
 				var commandInstance = TerminalCommand.FromMethod(method, instance);
 
-				CommandRegistry.RegisterCommand(commandInstance);
+				TerminalRegistry.RegisterCommand(commandInstance);
 
 				lock (Commands)
 				{
 					Commands.Add(commandInstance);
 				}
 			}
+
+			StringConverter.RegisterFrom(instance);
+
 			return instance;
 		}
 
@@ -57,7 +57,7 @@ namespace LethalAPI.TerminalCommands.Models
 
 			for (int i = 0; i < Commands.Count; i++)
 			{
-				CommandRegistry.Deregister(Commands[i]);
+				TerminalRegistry.Deregister(Commands[i]);
 			}
 		}
 	}

--- a/LethalAPI.TerminalCommands/Models/TerminalRegistry.cs
+++ b/LethalAPI.TerminalCommands/Models/TerminalRegistry.cs
@@ -10,23 +10,23 @@ namespace LethalAPI.TerminalCommands.Models
 	/// <summary>
 	/// Manages instances of terminal commands
 	/// </summary>
-	public class CommandRegistry
+	public class TerminalRegistry
 	{
 		/// <summary>
-		/// Dictionary containing all registered commands. You shouldn't be interfacing with this directly, instead use the APIs exposed by this class, or <seealso cref="ModCommands"/>.
+		/// Dictionary containing all registered commands. You shouldn't be interfacing with this directly, instead use the APIs exposed by this class, or <seealso cref="TerminalModRegistry"/>.
 		/// You can enumerate registered commands using <seealso cref="EnumerateCommands()"/> and <seealso cref="EnumerateCommands(string)"/>
 		/// </summary>
 		private static readonly ConcurrentDictionary<string, List<TerminalCommand>> m_RegisteredCommands = new ConcurrentDictionary<string, List<TerminalCommand>>(StringComparer.InvariantCultureIgnoreCase);
 
 		/// <summary>
-		/// Automatically registers all terminal commands from an instance, and returns a commands <seealso cref="ModCommands"/> token, which should be used to deregister all terminal commands when your mod unloads.
+		/// Automatically registers all terminal commands from an instance, and returns a commands <seealso cref="TerminalModRegistry"/> token, which should be used to deregister all terminal commands when your mod unloads.
 		/// </summary>
 		/// <typeparam name="T">Instance type</typeparam>
 		/// <param name="instance">Instance to execute commands in</param>
 		/// <returns>Token that can be used to register further commands, and also deregister commands when your mod unloads</returns>
-		public static ModCommands RegisterFrom<T>(T instance)
+		public static TerminalModRegistry RegisterFrom<T>(T instance) where T : class
 		{
-			var token = new ModCommands();
+			var token = new TerminalModRegistry();
 
 			foreach (var method in GetCommandMethods<T>())
 			{
@@ -36,6 +36,8 @@ namespace LethalAPI.TerminalCommands.Models
 				token.Commands.Add(command);
 			}
 
+			StringConverter.RegisterFrom(instance);
+
 			return token;
 		}
 
@@ -43,9 +45,9 @@ namespace LethalAPI.TerminalCommands.Models
 		/// Creates a mod-specific terminal command registry, to allow registration and deregistration of commands
 		/// </summary>
 		/// <returns>Mod terminal command registry</returns>
-		public static ModCommands CreateTerminalRegistry()
+		public static TerminalModRegistry CreateTerminalRegistry()
 		{
-			return new ModCommands();
+			return new TerminalModRegistry();
 		}
 
 		/// <summary>
@@ -69,7 +71,7 @@ namespace LethalAPI.TerminalCommands.Models
 		}
 
 		/// <summary>
-		/// De-registers a command instance. You should call <seealso cref="ModCommands.Deregister"/> (returned by <seealso cref="RegisterFrom{T}(T)"/>) instead.
+		/// De-registers a command instance. You should call <seealso cref="TerminalModRegistry.Deregister"/> (returned by <seealso cref="RegisterFrom{T}(T)"/>) instead.
 		/// </summary>
 		/// <remarks>
 		/// Primarily intended for internal use

--- a/LethalAPI.TerminalCommands/TerminalCommandsPlugin.cs
+++ b/LethalAPI.TerminalCommands/TerminalCommandsPlugin.cs
@@ -11,7 +11,7 @@ namespace LethalAPI.TerminalCommands
 	{
 		private Harmony HarmonyInstance = new Harmony(PluginInfo.PLUGIN_GUID);
 
-		private ModCommands Terminal;
+		private TerminalModRegistry Terminal;
 
 		private TerminalConfig TerminalConfig;
 
@@ -27,7 +27,7 @@ namespace LethalAPI.TerminalCommands
 			Logger.LogInfo($"Registering built-in Commands");
 
 			// Create registry for the Terminals API
-			Terminal = CommandRegistry.CreateTerminalRegistry();
+			Terminal = TerminalRegistry.CreateTerminalRegistry();
 
 			// Register commands, don't care about the instance
 			Terminal.RegisterFrom<CommandInfoCommands>();


### PR DESCRIPTION
* Overhauled the StringConverter system from .NET `StringTypeConverter`, to a custom conversion system
* String converters are methods annotated with `StringConverterAttribute`, take a single string as a parameter, and return a type, or throw an `InvalidArgumentException`
* Mod developers can now declare their own string converters to inject custom types into commands, with the `RegisterFrom` methods
* Renamed `CommandRegistry` to `TerminalRegistry`, and `ModCommands` to `TerminalModRegistry`, to reflect the additional features to the mod