### PR TITLE
V1 final changes

### DIFF
--- a/LethalAPI.Terminal/Attributes/AllowedCallerAttribute.cs
+++ b/LethalAPI.Terminal/Attributes/AllowedCallerAttribute.cs
@@ -3,10 +3,10 @@ using LethalAPI.LibTerminal.Models.Enums;
 
 namespace LethalAPI.LibTerminal.Attributes
 {
-    /// <summary>
-    /// Specifies what permission level is required for this command
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+	/// <summary>
+	/// Specifies what permission level is required for this command
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
 	public class AllowedCallerAttribute : AccessControlAttribute
 	{
 		/// <summary>

--- a/LethalAPI.Terminal/Attributes/StringConverterAttribute.cs
+++ b/LethalAPI.Terminal/Attributes/StringConverterAttribute.cs
@@ -2,21 +2,21 @@
 
 namespace LethalAPI.LibTerminal.Attributes
 {
-	/// <summary>
-	/// Marks a method as a string converter.
-	/// </summary>
-	/// <remarks>
-	/// <para>
-	/// String converter methods must take a single argument of a <see langword="string"/>, and return the object type they convert the string to.
-	/// </para>
-	/// <para>
-	/// String converters may throw <seealso cref="ArgumentException"/> if the string cannot be parsed.
-	/// </para>
-	/// <para>
-	/// String converters must be registered using <seealso cref="Models.TerminalRegistry.RegisterFrom{T}(T)"/>
-	/// </para>
-	/// </remarks>
-	public sealed class StringConverterAttribute : Attribute
+    /// <summary>
+    /// Marks a method as a string converter.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// String converter methods must take a single argument of a <see langword="string"/>, and return the object type they convert the string to.
+    /// </para>
+    /// <para>
+    /// String converters may throw <seealso cref="ArgumentException"/> if the string cannot be parsed.
+    /// </para>
+    /// <para>
+    /// String converters must be registered using <seealso cref="TerminalRegistry.RegisterFrom{T}(T)"/>
+    /// </para>
+    /// </remarks>
+    public sealed class StringConverterAttribute : Attribute
 	{
 	}
 }

--- a/LethalAPI.Terminal/Attributes/StringConverterAttribute.cs
+++ b/LethalAPI.Terminal/Attributes/StringConverterAttribute.cs
@@ -2,21 +2,21 @@
 
 namespace LethalAPI.LibTerminal.Attributes
 {
-    /// <summary>
-    /// Marks a method as a string converter.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// String converter methods must take a single argument of a <see langword="string"/>, and return the object type they convert the string to.
-    /// </para>
-    /// <para>
-    /// String converters may throw <seealso cref="ArgumentException"/> if the string cannot be parsed.
-    /// </para>
-    /// <para>
-    /// String converters must be registered using <seealso cref="TerminalRegistry.RegisterFrom{T}(T)"/>
-    /// </para>
-    /// </remarks>
-    public sealed class StringConverterAttribute : Attribute
+	/// <summary>
+	/// Marks a method as a string converter.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// String converter methods must take a single argument of a <see langword="string"/>, and return the object type they convert the string to.
+	/// </para>
+	/// <para>
+	/// String converters may throw <seealso cref="ArgumentException"/> if the string cannot be parsed.
+	/// </para>
+	/// <para>
+	/// String converters must be registered using <seealso cref="TerminalRegistry.RegisterFrom{T}(T)"/>
+	/// </para>
+	/// </remarks>
+	public sealed class StringConverterAttribute : Attribute
 	{
 	}
 }

--- a/LethalAPI.Terminal/Commands/CommandInfoCommands.cs
+++ b/LethalAPI.Terminal/Commands/CommandInfoCommands.cs
@@ -5,10 +5,10 @@ using LethalAPI.LibTerminal.Models;
 
 namespace LethalAPI.LibTerminal.Commands
 {
-    /// <summary>
-    /// Contains Terminal Command definitions for the built-in help commands
-    /// </summary>
-    public class CommandInfoCommands
+	/// <summary>
+	/// Contains Terminal Command definitions for the built-in help commands
+	/// </summary>
+	public class CommandInfoCommands
 	{
 		[TerminalCommand("Other", clearText: true)]
 		public string CommandList()

--- a/LethalAPI.Terminal/Commands/CommandInfoCommands.cs
+++ b/LethalAPI.Terminal/Commands/CommandInfoCommands.cs
@@ -5,10 +5,10 @@ using LethalAPI.LibTerminal.Models;
 
 namespace LethalAPI.LibTerminal.Commands
 {
-	/// <summary>
-	/// Contains Terminal Command definitions for the built-in help commands
-	/// </summary>
-	public class CommandInfoCommands
+    /// <summary>
+    /// Contains Terminal Command definitions for the built-in help commands
+    /// </summary>
+    public class CommandInfoCommands
 	{
 		[TerminalCommand("Other", clearText: true)]
 		public string CommandList()

--- a/LethalAPI.Terminal/Interactions/ConfirmInteraction.cs
+++ b/LethalAPI.Terminal/Interactions/ConfirmInteraction.cs
@@ -17,7 +17,7 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// <summary>
 		/// Command response/interaction prompt to display to the user
 		/// </summary>
-		public TerminalNode Prompt { get; private set; }
+		public TerminalNode? Prompt { get; private set; }
 
 		/// <summary>
 		/// Services to provide to the interaction handlers
@@ -27,12 +27,12 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// <summary>
 		/// Delegate executed when the action is confirmed
 		/// </summary>
-		public Delegate ConfirmHandler { get; set; }
+		public Delegate? ConfirmHandler { get; set; }
 
 		/// <summary>
 		/// Delegate execution when the action is denied, or an ambiguous response is received
 		/// </summary>
-		public Delegate DenyHandler { get; set; }
+		public Delegate? DenyHandler { get; set; }
 
 		/// <summary>
 		/// Creates en empty confirmation interaction
@@ -234,7 +234,7 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// </summary>
 		/// <param name="arguments">Arguments provided by the user</param>
 		/// <returns>Interaction response, or <see langword="null"/></returns>
-		public object HandleTerminalResponse(ArgumentStream arguments)
+		public object? HandleTerminalResponse(ArgumentStream arguments)
 		{
 			if (!arguments.TryReadNext(out string response))
 			{
@@ -254,14 +254,15 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// </summary>
 		/// <param name="arguments">Arguments provided by the user</param>
 		/// <returns>Response object</returns>
-		private object Confirm(ArgumentStream arguments)
+		private object? Confirm(ArgumentStream arguments)
 		{
 			if (DenyHandler == null)
 			{
 				return string.Empty;
 			}
 
-			if (CommandActivator.TryCreateInvoker(arguments, Services, ConfirmHandler.GetMethodInfo(), out var invoker))
+			if (ConfirmHandler != null && CommandActivator.TryCreateInvoker(arguments, Services, ConfirmHandler.GetMethodInfo(), out var invoker)
+				&& invoker != null)
 			{
 				return invoker(ConfirmHandler.Target);
 			}
@@ -274,14 +275,14 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// </summary>
 		/// <param name="arguments">Arguments provided by the user</param>
 		/// <returns>Response object</returns>
-		private object Deny(ArgumentStream arguments)
+		private object? Deny(ArgumentStream arguments)
 		{
 			if (DenyHandler == null)
 			{
 				return string.Empty;
 			}
 
-			if (CommandActivator.TryCreateInvoker(arguments, Services, DenyHandler.GetMethodInfo(), out var invoker))
+			if (CommandActivator.TryCreateInvoker(arguments, Services, DenyHandler.GetMethodInfo(), out var invoker) && invoker != null)
 			{
 				return invoker(DenyHandler.Target);
 			}
@@ -293,11 +294,14 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// </summary>
 		private void PostprocessPrompt()
 		{
-			var text = Prompt.displayText ?? string.Empty;
+			if (Prompt != null)
+			{
+				var text = Prompt.displayText ?? string.Empty;
 
-			text = TextUtil.SetEndPadding(text, '\n', 2) + "Please CONFIRM or DENY.\n";
+				text = TextUtil.SetEndPadding(text, '\n', 2) + "Please CONFIRM or DENY.\n";
 
-			Prompt.displayText = text;
+				Prompt.displayText = text;
+			}
 		}
 	}
 }

--- a/LethalAPI.Terminal/Interactions/TerminalInteraction.cs
+++ b/LethalAPI.Terminal/Interactions/TerminalInteraction.cs
@@ -19,7 +19,7 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// <summary>
 		/// The prompt displayed to the user
 		/// </summary>
-		public TerminalNode Prompt { get; private set; }
+		public TerminalNode? Prompt { get; private set; }
 
 		/// <summary>
 		/// Services containing the context for the handlers
@@ -137,7 +137,7 @@ namespace LethalAPI.LibTerminal.Interactions
 		/// </summary>
 		/// <param name="arguments">User provided arguments</param>
 		/// <returns>Object representing the response of this interaction, or <see langword="null"/> if execution should fall through to the parent interaction, or command handler</returns>
-		public object HandleTerminalResponse(ArgumentStream arguments)
+		public object? HandleTerminalResponse(ArgumentStream arguments)
 		{
 			// Converts all delegates into a list of Method Info and instances, ordered descending by parameter count (execution order)
 			List<(MethodInfo info, object instance)> handlers =
@@ -151,7 +151,7 @@ namespace LethalAPI.LibTerminal.Interactions
 				var method = handler.GetMethodInfo();
 
 				arguments.Reset();
-				if (CommandActivator.TryCreateInvoker(arguments, Services, method, out var invoker))
+				if (CommandActivator.TryCreateInvoker(arguments, Services, method, out var invoker) && invoker != null)
 				{
 					var result = invoker(handler.Target);
 

--- a/LethalAPI.Terminal/Interactions/TerminalInteraction.cs
+++ b/LethalAPI.Terminal/Interactions/TerminalInteraction.cs
@@ -89,7 +89,6 @@ namespace LethalAPI.LibTerminal.Interactions
 			return this;
 		}
 
-
 		/// <summary>
 		/// Sets the command response. This is the response message to prompt the user for further input
 		/// </summary>
@@ -104,7 +103,6 @@ namespace LethalAPI.LibTerminal.Interactions
 
 			return this;
 		}
-
 
 		/// <summary>
 		/// Sets the command response. This is the response message to prompt the user for further input

--- a/LethalAPI.Terminal/Interfaces/ITerminalInteraction.cs
+++ b/LethalAPI.Terminal/Interfaces/ITerminalInteraction.cs
@@ -21,7 +21,7 @@ namespace LethalAPI.LibTerminal.Interfaces
 		/// <remarks>
 		/// This acts as the command response, and prompt for further information
 		/// </remarks>
-		TerminalNode Prompt { get; }
+		TerminalNode? Prompt { get; }
 
 		/// <summary>
 		/// The service collection that command context will be registered to
@@ -39,6 +39,6 @@ namespace LethalAPI.LibTerminal.Interfaces
 		/// </remarks>
 		/// <param name="arguments">Arguments provided by the user. This is the full argument input, including the first word that is commonly taken as the command name</param>
 		/// <returns>A <seealso cref="TerminalNode"/>, another <seealso cref="ITerminalInteraction"/>, an object that represents the response text from this interaction, or <see langword="null"/></returns>
-		object HandleTerminalResponse(ArgumentStream arguments);
+		object? HandleTerminalResponse(ArgumentStream arguments);
 	}
 }

--- a/LethalAPI.Terminal/LethalAPI.Terminal.csproj
+++ b/LethalAPI.Terminal/LethalAPI.Terminal.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
@@ -28,22 +28,10 @@
   </ItemGroup>
   
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Unity.Netcode.Runtime">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.Netcode.Runtime.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\Unity.TextMeshPro.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Lethal Company\Lethal Company_Data\Managed\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="Assembly-CSharp" HintPath="$(LC_REFERENCES)\Assembly-CSharp.dll" Publicize="True" Private="False" />
+    <Reference Include="Unity.Netcode.Runtime" HintPath="$(LC_REFERENCES)\Unity.Netcode.Runtime.dll" Private="False" />
+    <Reference Include="Unity.TextMeshPro" HintPath="$(LC_REFERENCES)\Unity.TextMeshPro.dll" Private="False" />
+    <Reference Include="UnityEngine.UI" HintPath="$(LC_REFERENCES)\UnityEngine.UI.dll" Private="False" />
   </ItemGroup>
   
   <ItemGroup>

--- a/LethalAPI.Terminal/LethalAPI.Terminal.csproj
+++ b/LethalAPI.Terminal/LethalAPI.Terminal.csproj
@@ -12,6 +12,8 @@
     <RepositoryUrl>https://github.com/LethalCompany/LethalAPI.Terminal</RepositoryUrl>
     <PackageTags>LethalCompany LethalCompanyMods</PackageTags>
     <RootNamespace>LethalAPI.LibTerminal</RootNamespace>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LethalAPI.Terminal/LibTerminalPlugin.cs
+++ b/LethalAPI.Terminal/LibTerminalPlugin.cs
@@ -6,7 +6,7 @@ using LethalAPI.LibTerminal.Models;
 namespace LethalAPI.LibTerminal
 {
 	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-	internal class TerminalLibPlugin : BaseUnityPlugin
+	internal class LibTerminalPlugin : BaseUnityPlugin
 	{
 		private readonly Harmony m_Harmony = new Harmony(PluginInfo.PLUGIN_GUID);
 
@@ -17,7 +17,7 @@ namespace LethalAPI.LibTerminal
 			Logger.LogInfo($"{PluginInfo.PLUGIN_GUID} is loading...");
 
 			Logger.LogInfo($"Installing patches");
-			m_Harmony.PatchAll(typeof(TerminalLibPlugin).Assembly);
+			m_Harmony.PatchAll(typeof(LibTerminalPlugin).Assembly);
 
 			Logger.LogInfo($"Registering built-in Commands");
 

--- a/LethalAPI.Terminal/Models/ArgumentStream.cs
+++ b/LethalAPI.Terminal/Models/ArgumentStream.cs
@@ -56,14 +56,13 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="type">The type to parse the string as</param>
 		/// <param name="value">Resulting object instance</param>
 		/// <returns><see langword="true"/> if the string could be parsed as the specified type</returns>
-		public bool TryReadNext(Type type, out object value)
+		public bool TryReadNext(Type type, out object? value)
 		{
 			if (EndOfStream)
 			{
 				value = null;
 				return false;
 			}
-
 			return StringConverter.TryConvert(Arguments[Index++], type, out value);
 		}
 
@@ -72,7 +71,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// </summary>
 		/// <param name="result">The remaining text in the stream</param>
 		/// <returns><see langword="true"/> if there was next to read, otherwise the end of the stream has been reached</returns>
-		public bool TryReadRemaining(out string result)
+		public bool TryReadRemaining(out string? result)
 		{
 			if (EndOfStream)
 			{

--- a/LethalAPI.Terminal/Models/CommandActivator.cs
+++ b/LethalAPI.Terminal/Models/CommandActivator.cs
@@ -19,13 +19,13 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="method">Method info that represents the terminal command</param>
 		/// <param name="invoker">Resulting invoker for the terminal command</param>
 		/// <returns><see langword="true"/> if the provided arguments and services are sufficient to invoke the command</returns>
-		public static bool TryCreateInvoker(ArgumentStream arguments, ServiceCollection services, MethodInfo method, out Func<object, object> invoker)
+		public static bool TryCreateInvoker(ArgumentStream arguments, ServiceCollection services, MethodInfo method, out Func<object, object?>? invoker)
 		{
 			var commandAttribute = method.GetCustomAttribute<TerminalCommandAttribute>();
 
 			var parameters = method.GetParameters();
 
-			var values = new object[parameters.Length];
+			var values = new object?[parameters.Length];
 
 			invoker = null;
 
@@ -41,7 +41,7 @@ namespace LethalAPI.LibTerminal.Models
 				}
 				else if (type == typeof(string) && parameter.GetCustomAttribute<RemainingTextAttribute>() != null)
 				{
-					if (arguments.TryReadRemaining(out var remaining))
+					if (arguments.TryReadRemaining(out var remaining) && remaining != null)
 					{
 						values[i] = remaining;
 						continue;
@@ -50,7 +50,7 @@ namespace LethalAPI.LibTerminal.Models
 					return false;
 				}
 
-				if (arguments.TryReadNext(type, out var value))
+				if (arguments.TryReadNext(type, out var value) && value != null)
 				{
 					values[i] = value;
 					continue;
@@ -69,7 +69,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// </summary>
 		/// <param name="arguments">Arguments used to execute this command. Must precisely match the parameters of <seealso cref="Method"/></param>
 		/// <returns>Resulting <seealso cref="TerminalNode"/> response, an <seealso cref="Interfaces.ITerminalInteraction"/>, or <see langword="null"/></returns>
-		private static object ExecuteCommand(MethodInfo method, object instance, object[] arguments, bool clearConsole)
+		private static object? ExecuteCommand(MethodInfo method, object instance, object?[] arguments, bool clearConsole)
 		{
 			object result;
 			try

--- a/LethalAPI.Terminal/Models/CommandHandler.cs
+++ b/LethalAPI.Terminal/Models/CommandHandler.cs
@@ -7,10 +7,10 @@ using UnityEngine;
 
 namespace LethalAPI.LibTerminal.Models
 {
-	/// <summary>
-	/// Handles terminal command execution
-	/// </summary>
-	public static class CommandHandler
+    /// <summary>
+    /// Handles terminal command execution
+    /// </summary>
+    public static class CommandHandler
 	{
 		/// <summary>
 		/// The current interaction depth.

--- a/LethalAPI.Terminal/Models/CommandHandler.cs
+++ b/LethalAPI.Terminal/Models/CommandHandler.cs
@@ -7,10 +7,10 @@ using UnityEngine;
 
 namespace LethalAPI.LibTerminal.Models
 {
-    /// <summary>
-    /// Handles terminal command execution
-    /// </summary>
-    public static class CommandHandler
+	/// <summary>
+	/// Handles terminal command execution
+	/// </summary>
+	public static class CommandHandler
 	{
 		/// <summary>
 		/// The current interaction depth.
@@ -28,7 +28,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <summary>
 		/// The current terminal interface all terminal input is being redirected to, or <see langword="null"/> if no interface is overriding the terminal system
 		/// </summary>
-		public static ITerminalInterface CurrentInterface { get; private set; }
+		public static ITerminalInterface? CurrentInterface { get; private set; }
 
 		/// <summary>
 		/// The interaction stack, for handling interaction layers
@@ -51,7 +51,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="command">The terminal command input</param>
 		/// <param name="terminal">Terminal instance that raised the command</param>
 		/// <returns>A <seealso cref="TerminalNode"/> response, or <see langword="null"/> if execution should fall-through to the game's command handler</returns>
-		public static TerminalNode HandleCommandInput(string command, Terminal terminal)
+		public static TerminalNode? HandleCommandInput(string command, Terminal terminal)
 		{
 			// Split terminal input into parts
 			var matches = m_SplitRegex.Matches(command.Trim());
@@ -87,7 +87,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="arguments">Full user input arguments, including the first word/'command name'</param>
 		/// <param name="terminal">The terminal instance that raised the input</param>
 		/// <returns>A <seealso cref="TerminalNode"/> representing a response from an interaction, or null if the input should be parsed as a command</returns>
-		public static TerminalNode ExecuteInteractions(ArgumentStream arguments, Terminal terminal)
+		public static TerminalNode? ExecuteInteractions(ArgumentStream arguments, Terminal terminal)
 		{
 			while (m_Interactions.Count > 0)
 			{
@@ -128,7 +128,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// Commands may also enter a terminal interaction, which consumes the next terminal input. 
 		/// Interactions can be handled by calling <seealso cref="ExecuteInteractions(ArgumentStream, Terminal)"/>, and only executing this method if it returns null
 		/// </remarks>
-		public static TerminalNode ExecuteCommand(ArgumentStream arguments, Terminal terminal)
+		public static TerminalNode? ExecuteCommand(ArgumentStream arguments, Terminal terminal)
 		{
 			arguments.Reset();
 			if (!arguments.TryReadNext(out string commandName))
@@ -152,7 +152,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// Commands may also enter a terminal interaction, which consumes the next terminal input. 
 		/// Interactions can be handled by calling <seealso cref="ExecuteInteractions(ArgumentStream, Terminal)"/>, and only executing this method if it returns null
 		/// </remarks>
-		public static TerminalNode ExecuteCommand(string commandName, ArgumentStream arguments, Terminal terminal)
+		public static TerminalNode? ExecuteCommand(string commandName, ArgumentStream arguments, Terminal terminal)
 		{
 			// Handle command interpretation
 
@@ -174,7 +174,7 @@ namespace LethalAPI.LibTerminal.Models
 				}
 
 				arguments.Reset();
-				if (!registeredCommand.TryCreateInvoker(arguments, services, out var invoker))
+				if (!registeredCommand.TryCreateInvoker(arguments, services, out var invoker) || invoker == null)
 				{
 					continue;
 				}
@@ -206,7 +206,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// </summary>
 		/// <param name="result">Result to parse into a <seealso cref="TerminalNode"/></param>
 		/// <returns><seealso cref="TerminalNode"/> command display response</returns>
-		private static TerminalNode HandleCommandResult(object result, Terminal terminal)
+		private static TerminalNode? HandleCommandResult(object? result, Terminal terminal)
 		{
 			if (result is TerminalNode node)
 			{

--- a/LethalAPI.Terminal/Models/DefaultStringConverters.cs
+++ b/LethalAPI.Terminal/Models/DefaultStringConverters.cs
@@ -134,7 +134,7 @@ namespace LethalAPI.LibTerminal.Models
 				throw new ArgumentException("Game has not started");
 			}
 
-			PlayerControllerB player = null;
+			PlayerControllerB? player = null;
 			if (ulong.TryParse(value, out var steamID))
 			{
 				player = StartOfRound.Instance.allPlayerScripts

--- a/LethalAPI.Terminal/Models/Enums/AllowedCaller.cs
+++ b/LethalAPI.Terminal/Models/Enums/AllowedCaller.cs
@@ -1,26 +1,26 @@
 ﻿namespace LethalAPI.LibTerminal.Models.Enums
 {
-    /// <summary>
-    /// Player permission levels
-    /// </summary>
-    public enum AllowedCaller
-    {
-        /// <summary>
-        /// Nil permission level, deny everyone.
-        /// </summary>
-        None = -1,
+	/// <summary>
+	/// Player permission levels
+	/// </summary>
+	public enum AllowedCaller
+	{
+		/// <summary>
+		/// Nil permission level, deny everyone.
+		/// </summary>
+		None = -1,
 
-        /// <summary>
-        /// Default permission level, all players have access
-        /// </summary>
-        Player = 0,
+		/// <summary>
+		/// Default permission level, all players have access
+		/// </summary>
+		Player = 0,
 
-        /// <summary>
-        /// Only the lobby host has access
-        /// </summary>
-        /// <remarks>
-        /// Beyond access control, this permission level can be useful to restrict commands that can only execute on the host system
-        /// </remarks>
-        Host = 1
-    }
+		/// <summary>
+		/// Only the lobby host has access
+		/// </summary>
+		/// <remarks>
+		/// Beyond access control, this permission level can be useful to restrict commands that can only execute on the host system
+		/// </remarks>
+		Host = 1
+	}
 }

--- a/LethalAPI.Terminal/Models/RegisteredStringConverter.cs
+++ b/LethalAPI.Terminal/Models/RegisteredStringConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace LethalAPI.LibTerminal.Models
+{
+	/// <summary>
+	/// Represents a registered string converter, to allow a converter to be de-registered
+	/// </summary>
+	public readonly struct RegisteredStringConverter
+	{
+		/// <summary>
+		/// The resulting type of the string converter
+		/// </summary>
+		public Type Type { get; }
+
+		/// <summary>
+		/// The string converter instance
+		/// </summary>
+		public StringConversionHandler Handler { get; }
+
+		public RegisteredStringConverter(Type type, StringConversionHandler handler)
+		{
+			Type = type;
+			Handler = handler;
+		}
+	}
+}

--- a/LethalAPI.Terminal/Models/ServiceCollection.cs
+++ b/LethalAPI.Terminal/Models/ServiceCollection.cs
@@ -11,7 +11,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <summary>
 		/// Type -> Service Instance mapping for services registered to this container
 		/// </summary>
-		private Dictionary<Type, object> m_Services = new Dictionary<Type, object>();
+		private Dictionary<Type, object?> m_Services = new Dictionary<Type, object?>();
 
 		/// <summary>
 		/// Creates a new container with the specified services
@@ -35,7 +35,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="t">Type of the service to fetch</param>
 		/// <param name="service">Service instance, or <see langword="null"/></param>
 		/// <returns><see langword="true"/> if the service could be fetched from the container</returns>
-		public bool TryGetService(Type t, out object service)
+		public bool TryGetService(Type t, out object? service)
 		{
 			if (m_Services == null)
 			{

--- a/LethalAPI.Terminal/Models/StringConverter.cs
+++ b/LethalAPI.Terminal/Models/StringConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Reflection;
 using LethalAPI.LibTerminal.Attributes;
 
@@ -23,7 +24,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <remarks>
 		/// Register new converters using <seealso cref="RegisterFrom{T}(object, bool)"/>
 		/// </remarks>
-		public static ConcurrentDictionary<Type, StringConversionHandler> StringConverters { get; } = new ConcurrentDictionary<Type, StringConversionHandler>();
+		private static ConcurrentDictionary<Type, List<StringConversionHandler>> m_StringConverters { get; } = new ConcurrentDictionary<Type, List<StringConversionHandler>>();
 
 		/// <summary>
 		/// Specifies if the default string converters have been registered yet
@@ -42,23 +43,26 @@ namespace LethalAPI.LibTerminal.Models
 			if (!m_Initialized)
 			{
 				m_Initialized = true;
-				RegisterFromType(typeof(DefaultStringConverters), replaceExisting: false);
+				RegisterFromType(typeof(DefaultStringConverters));
 			}
 
-			if (!StringConverters.TryGetValue(type, out var converter))
+			if (!m_StringConverters.TryGetValue(type, out var converters))
 			{
 				result = null;
 				return false;
 			}
 
-			try
+			for (int i = 0; i < converters.Count; i++)
 			{
-				result = converter(value);
-				return true;
-			}
-			catch (Exception)
-			{
-				// Failed to parse as type, return null
+				try
+				{
+					result = converters[i](value);
+					return true;
+				}
+				catch (Exception)
+				{
+					// Failed to parse as type, try next handler
+				}
 			}
 
 			result = null;
@@ -74,9 +78,34 @@ namespace LethalAPI.LibTerminal.Models
 		/// <typeparam name="T">Type to register from</typeparam>
 		/// <param name="instance">Class instance</param>
 		/// <param name="replaceExisting">When <see langword="true"/>, existing converters for types will be replaced</param>
-		public static void RegisterFrom<T>(T instance, bool replaceExisting = true) where T : class
+		public static List<RegisteredStringConverter> RegisterFrom<T>(T instance) where T : class
 		{
-			RegisterFromType(typeof(T), instance, replaceExisting);
+			return RegisterFromType(typeof(T), instance);
+		}
+
+		/// <summary>
+		/// Deregisters a string converter by it's type, with the specified converter instance.
+		/// </summary>
+		/// <param name="converter">The string converter to de-register</param>
+		/// <returns><see langword="true"/> if the handler could be removed, <see langword="false"/> otherwise</returns>
+		public static bool Deregister(RegisteredStringConverter converter)
+		{
+			if (!m_StringConverters.TryGetValue(converter.Type, out var converters))
+			{
+				return false;
+			}
+
+			return converters.Remove(converter.Handler);
+		}
+
+		/// <summary>
+		/// Checks if a handler is available to convert to the specified type
+		/// </summary>
+		/// <param name="type">The desired type to convert strings to</param>
+		/// <returns><see langword="true"/> if a string converter is available for the specified type</returns>
+		public static bool CanConvert(Type type)
+		{
+			return m_StringConverters.ContainsKey(type);
 		}
 
 		/// <summary>
@@ -87,9 +116,9 @@ namespace LethalAPI.LibTerminal.Models
 		/// </remarks>
 		/// <param name="type">The class type to register from</param>
 		/// <param name="instance">Class instance, or null if the class is static</param>
-		/// <param name="replaceExisting">When <see langword="true"/>, existing converters for types will be replaced</param>
-		public static void RegisterFromType(Type type, object instance = null, bool replaceExisting = true)
+		public static List<RegisteredStringConverter> RegisterFromType(Type type, object instance = null)
 		{
+			var results = new List<RegisteredStringConverter>();
 			foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
 			{
 				if (method.GetCustomAttribute<StringConverterAttribute>() == null)
@@ -112,14 +141,21 @@ namespace LethalAPI.LibTerminal.Models
 				var resultingType = method.ReturnType;
 
 				var converter = new StringConversionHandler(
-					(value) => method.Invoke(instance, new object[] { value })
+					(value) => method.Invoke(instance, [value])
 				);
 
-				if (replaceExisting || !StringConverters.ContainsKey(resultingType))
+				if (!m_StringConverters.TryGetValue(resultingType, out var handlers))
 				{
-					StringConverters[resultingType] = converter;
+					handlers = new List<StringConversionHandler>();
+					m_StringConverters[resultingType] = handlers;
 				}
+
+				handlers.Add(converter);
+
+				results.Add(new RegisteredStringConverter(resultingType, converter));
 			}
+
+			return results;
 		}
 	}
 }

--- a/LethalAPI.Terminal/Models/StringConverter.cs
+++ b/LethalAPI.Terminal/Models/StringConverter.cs
@@ -38,7 +38,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="type">The type to parse the string as</param>
 		/// <param name="result">Resulting object instance, or <see langword="null"/></param>
 		/// <returns><see langword="true"/> if the string could be parsed as the specified type</returns>
-		public static bool TryConvert(string value, Type type, out object result)
+		public static bool TryConvert(string value, Type type, out object? result)
 		{
 			if (!m_Initialized)
 			{
@@ -116,7 +116,7 @@ namespace LethalAPI.LibTerminal.Models
 		/// </remarks>
 		/// <param name="type">The class type to register from</param>
 		/// <param name="instance">Class instance, or null if the class is static</param>
-		public static List<RegisteredStringConverter> RegisterFromType(Type type, object instance = null)
+		public static List<RegisteredStringConverter> RegisterFromType(Type type, object? instance = null)
 		{
 			var results = new List<RegisteredStringConverter>();
 			foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))

--- a/LethalAPI.Terminal/Models/TerminalCommand.cs
+++ b/LethalAPI.Terminal/Models/TerminalCommand.cs
@@ -38,12 +38,12 @@ namespace LethalAPI.LibTerminal.Models
 		/// <summary>
 		/// Optional command syntax
 		/// </summary>
-		public string Syntax { get; }
+		public string? Syntax { get; }
 
 		/// <summary>
 		/// Optional command description. This value being set enrols the command to be shown in help commands
 		/// </summary>
-		public string Description { get; }
+		public string? Description { get; }
 
 		/// <summary>
 		/// Command execution priority, with a default of 0.
@@ -52,7 +52,7 @@ namespace LethalAPI.LibTerminal.Models
 
 		private ManualLogSource m_LogSource = new ManualLogSource("LethalAPI.Terminal");
 
-		public TerminalCommand(string name, MethodInfo method, object instance, bool clearConsole, string syntax = null, string description = null, int priority = 0)
+		public TerminalCommand(string name, MethodInfo method, object instance, bool clearConsole, string? syntax = null, string? description = null, int priority = 0)
 		{
 			Name = name;
 			Method = method;
@@ -89,12 +89,12 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="instance">Object instance to execute the command in</param>
 		/// <param name="overrideName">Optional command name override</param>
 		/// <returns>Terminal command instance</returns>
-		public static TerminalCommand FromMethod(MethodInfo info, object instance, string overrideName = null)
+		public static TerminalCommand FromMethod(MethodInfo info, object instance, string? overrideName = null)
 		{
 			var clear = false;
-			string syntax = null;
-			string description = null;
-			string name = overrideName;
+			string? syntax = null;
+			string? description = null;
+			string? name = overrideName;
 			int priority = 0;
 
 			var command = info.GetCustomAttribute<TerminalCommandAttribute>();
@@ -117,6 +117,11 @@ namespace LethalAPI.LibTerminal.Models
 				priority = priorityValue.Priority;
 			}
 
+			if (name == null)
+			{
+				throw new ArgumentException("No override name provided, and command name could not be resolved from method");
+			}
+
 			return new TerminalCommand(name, info, instance, clear, syntax, description, priority);
 		}
 
@@ -127,10 +132,10 @@ namespace LethalAPI.LibTerminal.Models
 		/// <param name="terminal">Terminal instance that raised the command</param>
 		/// <param name="invoker">Delegate that executes the command using the specified arguments</param>
 		/// <returns><see langword="true"/> if the provided arguments match the signature for this command, and could be parsed correctly.</returns>
-		public bool TryCreateInvoker(ArgumentStream arguments, ServiceCollection services, out Func<object> invoker)
+		public bool TryCreateInvoker(ArgumentStream arguments, ServiceCollection services, out Func<object?>? invoker)
 		{
 
-			if (CommandActivator.TryCreateInvoker(arguments, services, Method, out var activatedInvoker))
+			if (CommandActivator.TryCreateInvoker(arguments, services, Method, out var activatedInvoker) && activatedInvoker != null)
 			{
 				invoker = () => activatedInvoker(Instance);
 				return true;

--- a/LethalAPI.Terminal/Models/TerminalModRegistry.cs
+++ b/LethalAPI.Terminal/Models/TerminalModRegistry.cs
@@ -13,6 +13,11 @@ namespace LethalAPI.LibTerminal.Models
 		public List<TerminalCommand> Commands { get; } = new List<TerminalCommand>();
 
 		/// <summary>
+		/// String converters registered to this instance
+		/// </summary>
+		public List<RegisteredStringConverter> StringConverters { get; } = new List<RegisteredStringConverter>();
+
+		/// <summary>
 		/// Creates a new instance of the specified type, and registers all commands from it
 		/// </summary>
 		/// <typeparam name="T">The type to register commands from</typeparam>
@@ -40,25 +45,27 @@ namespace LethalAPI.LibTerminal.Models
 				}
 			}
 
-			StringConverter.RegisterFrom(instance);
+			StringConverters.AddRange(StringConverter.RegisterFrom(instance));
 
 			return instance;
 		}
 
 		/// <summary>
-		/// De-registers all commands that were previously registered to this container.
+		/// De-registers all commands and string converters that were previously registered to this container.
 		/// </summary>
 		public void Deregister()
 		{
-			if (Commands == null)
-			{
-				return;
-			}
-
 			for (int i = 0; i < Commands.Count; i++)
 			{
 				TerminalRegistry.Deregister(Commands[i]);
 			}
+			Commands.Clear();
+
+			for (int i = 0; i < StringConverters.Count; i++)
+			{
+				StringConverter.Deregister(StringConverters[i]);
+			}
+			StringConverters.Clear();
 		}
 	}
 }

--- a/LethalAPI.Terminal/Models/TextUtil.cs
+++ b/LethalAPI.Terminal/Models/TextUtil.cs
@@ -17,7 +17,7 @@
 		/// <returns>Response text to write to the terminal screen</returns>
 		public static string PostProcessResponse(Terminal terminal, string message)
 		{
-			if (terminal.GetLastLoadedNode()?.clearPreviousText ?? false)
+			if (terminal.GetLastLoadedNode()?.clearPreviousText ?? true)
 			{
 				// Previous node cleared the screen, set padding to 2 to prevent clipping with credits count
 				message = message.SetStartPadding('\n', 2);

--- a/LethalAPI.Terminal/Models/TextUtil.cs
+++ b/LethalAPI.Terminal/Models/TextUtil.cs
@@ -6,6 +6,33 @@
 	public static class TextUtil
 	{
 		/// <summary>
+		/// Performs the default LethalAPI.Terminal response text post processing.
+		/// </summary>
+		/// <remarks>
+		/// This method allows you perform the default text post processing inside of <seealso cref="Interfaces.ITerminalInterface.PreProcessText(Terminal, string)"/>,
+		/// when <seealso cref="Interfaces.ITerminalInterface.APITextPostProcessing"/> is set to <see langword="false"/>.
+		/// </remarks>
+		/// <param name="terminal">The terminal instance the text is being processed for</param>
+		/// <param name="message">The terminal text to post process</param>
+		/// <returns>Response text to write to the terminal screen</returns>
+		public static string PostProcessResponse(Terminal terminal, string message)
+		{
+			if (terminal.GetLastLoadedNode()?.clearPreviousText ?? false)
+			{
+				// Previous node cleared the screen, set padding to 2 to prevent clipping with credits count
+				message = message.SetStartPadding('\n', 2);
+			}
+			else
+			{
+				message = message.TrimStart('\n', ' ');
+			}
+
+			message = SetEndPadding(message, '\n', 2);
+
+			return message;
+		}
+
+		/// <summary>
 		/// Applies a minimum trailing character count to the end of a string, padding the end with the specified character until it reaches the specified number of trailing characters
 		/// </summary>
 		/// <param name="text">Text to apply minimum padding to</param>

--- a/LethalAPI.Terminal/Patches/BeginUsingTerminalPatch.cs
+++ b/LethalAPI.Terminal/Patches/BeginUsingTerminalPatch.cs
@@ -5,7 +5,7 @@ namespace LethalAPI.LibTerminal.Patches
 	/// <summary>
 	/// Loads the splash screen node of the current <seealso cref="Interfaces.ITerminalInterface"/>, so long as one is active.
 	/// </summary>
-	[HarmonyPatch(typeof(Terminal), "BeginUsingTerminal")]
+	[HarmonyPatch(typeof(Terminal), nameof(Terminal.BeginUsingTerminal))]
 	internal static class BeginUsingTerminalPatch
 	{
 		[HarmonyPostfix]

--- a/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
+++ b/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
@@ -5,7 +5,7 @@ namespace LethalAPI.LibTerminal.Patches
 	/// <summary>
 	/// Patch to catch the last loaded node in the terminal
 	/// </summary>
-	[HarmonyPatch(typeof(Terminal), "LoadNewNode")]
+	[HarmonyPatch(typeof(Terminal), nameof(Terminal.LoadNewNode))]
 	internal static class LoadNewNodePatch
 	{
 		/// <summary>

--- a/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
+++ b/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
@@ -1,0 +1,22 @@
+﻿using HarmonyLib;
+
+namespace LethalAPI.LibTerminal.Patches
+{
+	/// <summary>
+	/// Patch to catch the last loaded node in the terminal
+	/// </summary>
+	[HarmonyPatch(typeof(Terminal), "LoadNewNode")]
+	internal static class LoadNewNodePatch
+	{
+		/// <summary>
+		/// The last loaded terminal node
+		/// </summary>
+		public static TerminalNode LastLoadedNode { get; private set; }
+
+		[HarmonyPrefix]
+		public static void Prefix(TerminalNode node)
+		{
+			LastLoadedNode = node;
+		}
+	}
+}

--- a/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
+++ b/LethalAPI.Terminal/Patches/LoadNewNodePatch.cs
@@ -11,7 +11,7 @@ namespace LethalAPI.LibTerminal.Patches
 		/// <summary>
 		/// The last loaded terminal node
 		/// </summary>
-		public static TerminalNode LastLoadedNode { get; private set; }
+		public static TerminalNode? LastLoadedNode { get; private set; }
 
 		[HarmonyPrefix]
 		public static void Prefix(TerminalNode node)

--- a/LethalAPI.Terminal/Patches/ParseSentencePatch.cs
+++ b/LethalAPI.Terminal/Patches/ParseSentencePatch.cs
@@ -1,9 +1,8 @@
-﻿using LethalAPI.LibTerminal.Models;
-using LethalAPI.LibTerminal.Patches;
-using HarmonyLib;
+﻿using HarmonyLib;
+using LethalAPI.LibTerminal.Models;
 using UnityEngine.Video;
 
-namespace LethalAPI.LibTerminal
+namespace LethalAPI.LibTerminal.Patches
 {
 	/// <summary>
 	/// Patches the method used to parse player commands in the terminal, to redirect commands to the <seealso cref="CommandHandler"/>

--- a/LethalAPI.Terminal/Patches/ParseSentencePatch.cs
+++ b/LethalAPI.Terminal/Patches/ParseSentencePatch.cs
@@ -15,7 +15,7 @@ namespace LethalAPI.LibTerminal
 	internal static class ParseSentencePatch
 	{
 		[HarmonyPrefix]
-		public static bool ParsePrefix(Terminal __instance, ref TerminalNode __state)
+		public static bool ParsePrefix(Terminal __instance, ref TerminalNode? __state)
 		{
 			__state = null;
 			var commandText = __instance.screenText.text.Substring(__instance.screenText.text.Length - __instance.textAdded);
@@ -25,7 +25,7 @@ namespace LethalAPI.LibTerminal
 		}
 
 		[HarmonyPostfix]
-		public static TerminalNode ParsePostfix(TerminalNode __result, TerminalNode __state, Terminal __instance)
+		public static TerminalNode? ParsePostfix(TerminalNode? __result, TerminalNode? __state, Terminal __instance)
 		{
 			if (__state != null)
 			{

--- a/LethalAPI.Terminal/Patches/TerminalSubmitPatch.cs
+++ b/LethalAPI.Terminal/Patches/TerminalSubmitPatch.cs
@@ -19,7 +19,7 @@ namespace LethalAPI.LibTerminal.Patches
 		/// <summary>
 		/// Set by the <seealso cref="ParseSentencePatch"/>, to allow the postfix to access the last parsed node
 		/// </summary>
-		public static TerminalNode LastNode { get; set; }
+		public static TerminalNode? LastNode { get; set; }
 
 		private static ManualLogSource m_LogSource = new ManualLogSource("LethalAPI.Terminal");
 

--- a/LethalAPI.Terminal/Patches/TerminalSubmitPatch.cs
+++ b/LethalAPI.Terminal/Patches/TerminalSubmitPatch.cs
@@ -8,12 +8,12 @@ using UnityEngine;
 namespace LethalAPI.LibTerminal.Patches
 {
 	/// <summary>
-	/// Patches the submit method of the Terminal to modify its auto-scroll behaviour
+	/// Patches the submit method of the Terminal to modify its auto-scroll behavior
 	/// </summary>
 	/// <remarks>
 	/// By default, the game always scrolls to the top on command execution, this patch makes it so it only scrolls to the top on terminal clearance
 	/// </remarks>
-	[HarmonyPatch(typeof(Terminal), "OnSubmit")]
+	[HarmonyPatch(typeof(Terminal), nameof(Terminal.OnSubmit))]
 	internal static class TerminalSubmitPatch
 	{
 		/// <summary>

--- a/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
+++ b/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
@@ -20,7 +20,7 @@ namespace LethalAPI.LibTerminal.Patches
 	internal static class TextPostProcessPatch
 	{
 		[HarmonyPrefix]
-		public static bool Prefix(Terminal __instance, ref string modifiedDisplayText, ref string __state)
+		public static bool Prefix(Terminal __instance, ref string modifiedDisplayText, ref string? __state)
 		{
 			__state = null;
 
@@ -44,10 +44,10 @@ namespace LethalAPI.LibTerminal.Patches
 		}
 
 		[HarmonyPostfix]
-		public static string Postfix(string __result, Terminal __instance, string __state)
+		public static string? Postfix(string __result, Terminal __instance, string? __state)
 		{
 			// if __state is not null, the vanilla method didn't run.
-			string result = __state ?? __result;
+			var result = __state ?? __result;
 
 			if (CommandHandler.CurrentInterface != null)
 			{

--- a/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
+++ b/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using LethalAPI.LibTerminal.Interfaces;
 using LethalAPI.LibTerminal.Models;
 
@@ -25,6 +26,7 @@ namespace LethalAPI.LibTerminal.Patches
 
 			if (CommandHandler.CurrentInterface == null || CommandHandler.CurrentInterface.APITextPostProcessing)
 			{
+				Console.WriteLine("Run text post process");
 				modifiedDisplayText = TextUtil.PostProcessResponse(__instance, modifiedDisplayText);
 				return true;
 			}
@@ -57,11 +59,6 @@ namespace LethalAPI.LibTerminal.Patches
 
 		private static bool ProcessInterface(ITerminalInterface terminalInterface, ref string modifiedDisplayText, Terminal terminal)
 		{
-			if (terminalInterface.APITextPostProcessing)
-			{
-				modifiedDisplayText = TextUtil.SetEndPadding(modifiedDisplayText.TrimStart('\n', ' '), '\n', 2);
-			}
-
 			modifiedDisplayText = terminalInterface.PreProcessText(terminal, modifiedDisplayText);
 
 			return terminalInterface.VanillaTextPostProcessing;

--- a/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
+++ b/LethalAPI.Terminal/Patches/TextPostProcessPatch.cs
@@ -23,11 +23,13 @@ namespace LethalAPI.LibTerminal.Patches
 		{
 			__state = null;
 
-			if (CommandHandler.CurrentInterface == null)
+			if (CommandHandler.CurrentInterface == null || CommandHandler.CurrentInterface.APITextPostProcessing)
 			{
-				modifiedDisplayText = TextUtil.SetEndPadding(modifiedDisplayText.TrimStart('\n', ' '), '\n', 2);
+				modifiedDisplayText = TextUtil.PostProcessResponse(__instance, modifiedDisplayText);
 				return true;
 			}
+
+			// Current interface is not null, pass text processing onto the current interface
 
 			var runVanilla = ProcessInterface(CommandHandler.CurrentInterface, ref modifiedDisplayText, __instance);
 

--- a/LethalAPI.Terminal/TerminalExtensions.cs
+++ b/LethalAPI.Terminal/TerminalExtensions.cs
@@ -79,7 +79,7 @@ namespace LethalAPI.LibTerminal
 		/// and not just the last node that was loaded.
 		/// </remarks>
 		/// <returns>The last loaded terminal node</returns>
-		public static TerminalNode GetLastLoadedNode()
+		public static TerminalNode? GetLastLoadedNode()
 		{
 			// Exposes the last loaded node from the internal patch
 			return LoadNewNodePatch.LastLoadedNode;
@@ -93,7 +93,7 @@ namespace LethalAPI.LibTerminal
 		/// and not just the last node that was loaded.
 		/// </remarks>
 		/// <returns>The last loaded terminal node</returns>
-		public static TerminalNode GetLastLoadedNode(this Terminal terminal)
+		public static TerminalNode? GetLastLoadedNode(this Terminal terminal)
 		{
 			// Exposes the last loaded node from the internal patch
 			return LoadNewNodePatch.LastLoadedNode ?? terminal.currentNode;

--- a/LethalAPI.Terminal/TerminalExtensions.cs
+++ b/LethalAPI.Terminal/TerminalExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using LethalAPI.LibTerminal.Patches;
 using UnityEngine;
 using UnityEngine.Video;
 
@@ -68,6 +69,34 @@ namespace LethalAPI.LibTerminal
 			terminal.videoPlayer.url = url;
 
 			terminal.videoPlayer.enabled = true;
+		}
+
+		/// <summary>
+		/// Gets the last loaded terminal node, or the terminal node that is currently being loaded.
+		/// </summary>
+		/// <remarks>
+		/// Differs from <seealso cref="Terminal.currentNode"/> in that this will also provide the node that is currently being loaded,
+		/// and not just the last node that was loaded.
+		/// </remarks>
+		/// <returns>The last loaded terminal node</returns>
+		public static TerminalNode GetLastLoadedNode()
+		{
+			// Exposes the last loaded node from the internal patch
+			return LoadNewNodePatch.LastLoadedNode;
+		}
+
+		/// <summary>
+		/// Gets the last loaded terminal node, or the terminal node that is currently being loaded.
+		/// </summary>
+		/// <remarks>
+		/// Differs from <seealso cref="Terminal.currentNode"/> in that this will also provide the node that is currently being loaded,
+		/// and not just the last node that was loaded.
+		/// </remarks>
+		/// <returns>The last loaded terminal node</returns>
+		public static TerminalNode GetLastLoadedNode(this Terminal terminal)
+		{
+			// Exposes the last loaded node from the internal patch
+			return LoadNewNodePatch.LastLoadedNode ?? terminal.currentNode;
 		}
 	}
 }

--- a/LethalAPI.Terminal/TerminalLibPlugin.cs
+++ b/LethalAPI.Terminal/TerminalLibPlugin.cs
@@ -10,7 +10,7 @@ namespace LethalAPI.LibTerminal
 	{
 		private Harmony HarmonyInstance = new Harmony(PluginInfo.PLUGIN_GUID);
 
-		private TerminalModRegistry Terminal;
+		private TerminalModRegistry? Terminal;
 
 		private void Awake()
 		{

--- a/LethalAPI.Terminal/TerminalLibPlugin.cs
+++ b/LethalAPI.Terminal/TerminalLibPlugin.cs
@@ -5,27 +5,27 @@ using LethalAPI.LibTerminal.Models;
 
 namespace LethalAPI.LibTerminal
 {
-    [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 	internal class TerminalLibPlugin : BaseUnityPlugin
 	{
-		private Harmony HarmonyInstance = new Harmony(PluginInfo.PLUGIN_GUID);
+		private readonly Harmony m_Harmony = new Harmony(PluginInfo.PLUGIN_GUID);
 
-		private TerminalModRegistry? Terminal;
+		private TerminalModRegistry? m_Registry;
 
 		private void Awake()
 		{
 			Logger.LogInfo($"{PluginInfo.PLUGIN_GUID} is loading...");
 
 			Logger.LogInfo($"Installing patches");
-			HarmonyInstance.PatchAll(typeof(TerminalLibPlugin).Assembly);
+			m_Harmony.PatchAll(typeof(TerminalLibPlugin).Assembly);
 
 			Logger.LogInfo($"Registering built-in Commands");
 
 			// Create registry for the Terminals API
-			Terminal = TerminalRegistry.CreateTerminalRegistry();
+			m_Registry = TerminalRegistry.CreateTerminalRegistry();
 
 			// Register commands, don't care about the instance
-			Terminal.RegisterFrom<CommandInfoCommands>();
+			m_Registry.RegisterFrom<CommandInfoCommands>();
 
 			DontDestroyOnLoad(this);
 

--- a/LethalAPI.Terminal/TerminalLibPlugin.cs
+++ b/LethalAPI.Terminal/TerminalLibPlugin.cs
@@ -5,8 +5,8 @@ using LethalAPI.LibTerminal.Models;
 
 namespace LethalAPI.LibTerminal
 {
-	[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-	public class TerminalLibPlugin : BaseUnityPlugin
+    [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+	internal class TerminalLibPlugin : BaseUnityPlugin
 	{
 		private Harmony HarmonyInstance = new Harmony(PluginInfo.PLUGIN_GUID);
 

--- a/LethalAPI.Terminal/TerminalNodeExtensions.cs
+++ b/LethalAPI.Terminal/TerminalNodeExtensions.cs
@@ -15,9 +15,9 @@ namespace LethalAPI.LibTerminal
 		/// <param name="node">Terminal node to modify</param>
 		/// <param name="displayText">Text to display to the user, as the response of the command</param>
 		/// <returns>Original terminal node</returns>
-		public static TerminalNode WithDisplayText(this TerminalNode node, object displayText)
+		public static TerminalNode WithDisplayText(this TerminalNode node, object? displayText)
 		{
-			node.displayText = displayText.ToString();
+			node.displayText = displayText?.ToString() ?? string.Empty;
 			return node;
 		}
 

--- a/LethalAPI.Terminal/TerminalRegistry.cs
+++ b/LethalAPI.Terminal/TerminalRegistry.cs
@@ -4,8 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using LethalAPI.LibTerminal.Attributes;
+using LethalAPI.LibTerminal.Models;
 
-namespace LethalAPI.LibTerminal.Models
+namespace LethalAPI.LibTerminal
 {
 	/// <summary>
 	/// Manages instances of terminal commands
@@ -28,15 +29,7 @@ namespace LethalAPI.LibTerminal.Models
 		{
 			var token = new TerminalModRegistry();
 
-			foreach (var method in GetCommandMethods<T>())
-			{
-				var command = TerminalCommand.FromMethod(method, instance);
-				RegisterCommand(command);
-
-				token.Commands.Add(command);
-			}
-
-			StringConverter.RegisterFrom(instance);
+			token.RegisterFrom(instance);
 
 			return token;
 		}

--- a/README.md
+++ b/README.md
@@ -169,3 +169,6 @@ This mod also provides a few extension methods:
 
 
 
+  ## Building
+
+  Building this projects requires the `LC_REFERENCES` environment variable, containing the path to the *'Lethal Company_Data\Managed'* folder inside your installation of Lethal Company.


### PR DESCRIPTION
# Changelog
* Fixed issue with screen text overlapping with credits HUD element (#20)
* Enabled nullability
* Migrated codebase for nullability
* Code cleanup
* Misc changes
* String converters are now associated with a mod registry
* String converters can now be deregistered
* Multiple converters can be registered for a type

# Milestone
This branch is intended to provide the final changes before the 1.0 release on Thunderstore (#15). And as such, is the last opportunity to implement major breaking changes.

