### PR TITLE
Return `null` when handling command result

### DIFF
--- a/LethalAPI.Terminal/Models/CommandHandler.cs
+++ b/LethalAPI.Terminal/Models/CommandHandler.cs
@@ -179,7 +179,7 @@ namespace LethalAPI.LibTerminal.Models
 					continue;
 				}
 
-				// A pass-though delegate to execute interactions, and return the response `TerminalNode` or null
+				// A pass-through delegate to execute interactions, and return the response `TerminalNode` or null
 				var passThrough = () => HandleCommandResult(invoker(), terminal);
 
 				candidateCommands.Add((registeredCommand, passThrough));

--- a/LethalAPI.Terminal/Models/CommandHandler.cs
+++ b/LethalAPI.Terminal/Models/CommandHandler.cs
@@ -208,6 +208,11 @@ namespace LethalAPI.LibTerminal.Models
 		/// <returns><seealso cref="TerminalNode"/> command display response</returns>
 		private static TerminalNode? HandleCommandResult(object? result, Terminal terminal)
 		{
+			if (result is null)
+			{
+				return null;
+			}
+			
 			if (result is TerminalNode node)
 			{
 				return node;


### PR DESCRIPTION
When a command result is handled in [HandleCommandResult](https://github.com/LethalCompany/LethalAPI.Terminal/blob/development/LethalAPI.Terminal/Models/CommandHandler.cs#L209), a `TerminalNode` is always returned, even if the command's result is `null`. This prevents execution from being passed through to other user-defined commands and the game's command parser. There's also a comment [here](https://github.com/LethalCompany/LethalAPI.Terminal/blob/development/LethalAPI.Terminal/Models/CommandHandler.cs#L182) indicating that `HandleCommandResult` should return `TerminalNode` or `null`, but currently `null` is never returned.

This PR simply adds a condition in `HandleCommandResult` to return `null` when the command's result is `null` and fixes a typo in the comment mentioned previously.